### PR TITLE
Correct the note regarding assertJson

### DIFF
--- a/http-tests.md
+++ b/http-tests.md
@@ -98,7 +98,7 @@ Laravel also provides several helpers for testing JSON APIs and their responses.
         }
     }
 
-> {tip} The `assertJson` method converts the given array into JSON, and then verifies that the JSON fragment occurs **anywhere** within the entire JSON response returned by the application. So, if there are other properties in the JSON response, this test will still pass as long as the given fragment is present.
+> {tip} The `assertJson` method converts the response to an array and utilizes `PHPUnit::assertArraySubset` to verify that the given fragment exists within the JSON response returned by the application. So, if there are other properties in the JSON response, this test will still pass as long as the given fragment is present.
 
 <a name="verifying-exact-match"></a>
 ### Verifying Exact Match


### PR DESCRIPTION
The docs contain a kind of misleading note about the `assertJson` method, this fixes it along with #3075.